### PR TITLE
fix: set `loose: true` for plugin-proposal-private-property-in-object

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ module.exports = (api, options, dirname) => {
     require("@babel/plugin-syntax-import-meta"),
     [require("@babel/plugin-proposal-class-properties"), { loose: true }],
     [require("@babel/plugin-proposal-private-methods"), { loose: true }],
+    [require("@babel/plugin-proposal-private-property-in-object"), { loose: true }], // #38
     require("@babel/plugin-proposal-json-strings"),
 
     // compile time code generation

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/plugin-proposal-optional-chaining": "7.16.7",
     "@babel/plugin-proposal-pipeline-operator": "7.16.7",
     "@babel/plugin-proposal-private-methods": "7.16.11",
+    "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
     "@babel/plugin-proposal-throw-expressions": "7.16.7",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/plugin-syntax-import-meta": "7.10.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ importers:
       '@babel/plugin-proposal-optional-chaining': 7.16.7
       '@babel/plugin-proposal-pipeline-operator': 7.16.7
       '@babel/plugin-proposal-private-methods': 7.16.11
+      '@babel/plugin-proposal-private-property-in-object': ^7.16.7
       '@babel/plugin-proposal-throw-expressions': 7.16.7
       '@babel/plugin-syntax-dynamic-import': 7.8.3
       '@babel/plugin-syntax-import-meta': 7.10.4
@@ -53,6 +54,7 @@ importers:
       '@babel/plugin-proposal-optional-chaining': 7.16.7_@babel+core@7.13.14
       '@babel/plugin-proposal-pipeline-operator': 7.16.7_@babel+core@7.13.14
       '@babel/plugin-proposal-private-methods': 7.16.11_@babel+core@7.13.14
+      '@babel/plugin-proposal-private-property-in-object': 7.16.7_@babel+core@7.13.14
       '@babel/plugin-proposal-throw-expressions': 7.16.7_@babel+core@7.13.14
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.13.14
       '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.13.14


### PR DESCRIPTION
https://babeljs.io/docs/en/babel-plugin-proposal-private-property-in-object
This proposal is included in @babel/preset-env

https://babeljs.io/docs/en/babel-plugin-proposal-private-property-in-object#loose
`loose` is false by default...
And `loose` must be the same for this and class-properties

All the defaults align to cause a warning

And so, this sets [private-property-in-object, `loose: false`]